### PR TITLE
Cross-platform compatibility and URLencode fix

### DIFF
--- a/src/gapseq_find.sh
+++ b/src/gapseq_find.sh
@@ -32,7 +32,12 @@ update_manually=false
 user_temp=false
 force_offline=false
 input_mode="auto"
-n_threads=`grep -c ^processor /proc/cpuinfo`
+OS=$(uname -s)
+if [ "$OS" = "Darwin" -o "$OS" = "FreeBSD" ]; then
+	n_threads=$(sysctl hw.ncpu|cut -f2 -d' ')
+else
+	n_threads=`grep -c ^processor /proc/cpuinfo`
+fi
 
 usage()
 {

--- a/src/gapseq_find.sh
+++ b/src/gapseq_find.sh
@@ -338,7 +338,7 @@ mkdir -p $seqpath/rev $seqpath/unrev $seqpath_user
 #check for updates if internet connection is available
 if [[ "$force_offline" = false ]]; then
     is_online=$(wget -q --spider http://rz.uni-kiel.de)
-    is_running=$(pidof -x "$script_name" -o $$) # do not check for updates if running in parallel mode (several gapseq processes at once)
+    is_running=$(pgrep -f "bash.*$script_name" | grep -v "^$$") # do not check for updates if running in parallel mode (several gapseq processes at once)
     if [[ $is_online -eq 0 && -z "$is_running" ]]; then
         $dir/update_sequences.sh $taxonomy
     fi
@@ -1051,6 +1051,6 @@ sed -i "2s/^/# Sequence DB md5sum: $seqdb_version ($seqdb_date, $taxonomy)\n/" $
 [[ -s "$tmp_fasta" ]] && rm "$tmp_fasta"
 
 
-ps -p $$ -o %cpu,%mem,cmd
+ps -p $$ -o %cpu,%mem,args
 end_time=`date +%s`
 echo Running time: `expr $end_time - $start_time` s.

--- a/src/uniprot_query.R
+++ b/src/uniprot_query.R
@@ -47,7 +47,7 @@ args = commandArgs(trailingOnly=TRUE)
 
 # parse positional arguments
 query_type <- args[1]
-query_term <- args[2]
+query_term <- utils::URLencode(args[2])
 output_fasta_file <- args[3]
 taxonomy <- args[4]
 if(length(args)==6) {


### PR DESCRIPTION
This PR fixes a few compatibility issues in `gapseq_find.sh` when running on Mac (and I think FreeBSD, but didn't test). Specifically, pidof on Mac doesn't support the `-x` flag, and ps doesn't recognize `cmd` as a format specifier. There's also code for determining the number of CPU cores.

Moreover, the PR contains a fix for URL encoding in `uniprot_query.R`. The protein name is not properly encoded, leading to a malformed url being passed to httr::GET, e.g.:
```
> library(httr)
> x <- GET('https://rest.uniprot.org/uniprotkb/search?format=list&query=(protein_name:3,6-dichlorocatechol 1,2-dioxygenase)%20AND%20((taxonomy_name:Bacteria))%20AND%20(reviewed:false)&size=500')
Error in curl::curl_fetch_memory(url, handle = handle) : 
  URL using bad/illegal format or missing URL
> x <- GET('https://rest.uniprot.org/uniprotkb/search?format=list&query=(protein_name:3,6-dichlorocatechol%201,2-dioxygenase)%20AND%20((taxonomy_name:Bacteria))%20AND%20(reviewed:false)&size=500')
> 
```

Sorry for putting both in the same PR, I'm still a bit uncomfortable with git.