### PR TITLE
transporter.sh: detect number of cores on mac and freebsd

### DIFF
--- a/src/transporter.sh
+++ b/src/transporter.sh
@@ -10,7 +10,12 @@ use_parallel=true
 only_met=""
 verbose=1
 input_mode="auto"
-n_threads=`grep -c ^processor /proc/cpuinfo`
+OS=$(uname -s)
+if [ "$OS" = "Darwin" -o "$OS" = "FreeBSD" ]; then
+	n_threads=$(sysctl hw.ncpu|cut -f2 -d' ')
+else
+	n_threads=`grep -c ^processor /proc/cpuinfo`
+fi
 
 usage()
 {


### PR DESCRIPTION
Missed that transporter.sh needs the same changes as gapseq_find.sh.