### PR TITLE
Use mt_mode 1 for improved blast performance in transporter.sh

### DIFF
--- a/src/transporter.sh
+++ b/src/transporter.sh
@@ -147,10 +147,10 @@ awk 'BEGIN{while((getline<"fasta_header.small")>0)l[$1]=1}/^>/{f=l[$1]}f' all.fa
 
 makeblastdb -in $fasta -dbtype $input_mode -out orgdb >/dev/null
 if [ "$input_mode" == "nucl" ]; then
-    tblastn -db orgdb -qcov_hsp_perc $covcutoff -outfmt "6 $blast_format" -query small.fasta > out
+    tblastn -db orgdb -qcov_hsp_perc $covcutoff -num_threads $n_threads -mt_mode 1 -outfmt "6 $blast_format" -query small.fasta > out
 fi
 if [ "$input_mode" == "prot" ]; then
-    blastp -db orgdb -qcov_hsp_perc $covcutoff -num_threads $n_threads -outfmt "6 $blast_format" -query small.fasta > out
+    blastp -db orgdb -qcov_hsp_perc $covcutoff -num_threads $n_threads -mt_mode 1 -outfmt "6 $blast_format" -query small.fasta > out
 fi
 
 


### PR DESCRIPTION
In transporter.sh, nucleotide fasta inputs are not run in multithreaded mode. Also, using `-mt_mode 1` seems to give better CPU utilization:

```
Nucleotide fasta, single-threaded (current version):
( for i in 1 2 3; do; ./gapseq find-transport prop_thermo/MAG9.fna; done; )  370.04s user 64.56s system 101% cpu 7:08.99 total

Nucleotide fasta, added -num_threads:
( for i in 1 2 3; do; ./gapseq find-transport prop_thermo/MAG9.fna; done; )  397.28s user 66.42s system 219% cpu 3:31.31 total

Nucleotide fasta, added -mt_mode 1:
( for i in 1 2 3; do; ./gapseq find-transport prop_thermo/MAG9.fna; done; )  429.10s user 64.08s system 360% cpu 2:16.96 total

Protein fasta, multi-threaded (current version):
( for i in 1 2 3; do; ./gapseq find-transport prop_thermo/MAG9.faa; done; )  482.92s user 78.75s system 298% cpu 3:08.44 total

Protein fasta, added -mt_mode 1:
( for i in 1 2 3; do; ./gapseq find-transport prop_thermo/MAG9.faa; done; )  494.63s user 75.74s system 353% cpu 2:41.48 total
```