### PR TITLE
Fix doall options (issue #192)

### DIFF
--- a/gapseq
+++ b/gapseq
@@ -72,7 +72,7 @@ done
 parse_options=true
 
 if [[ "$1" == "doall" ]]; then
-    # If yes set OPTIND 2 to avoid reading "gapseq doall" and to parse all the optins in the following while.
+    # If yes set OPTIND 2 to avoid reading "gapseq doall" and to parse all the options in the following while.
     subcommand=$1
     OPTIND=2
 elif [[ "$1" =~ ^(test|find|find-transport|draft|adapt|medium|fill)$ ]]; then
@@ -82,7 +82,7 @@ elif [[ "$1" =~ ^(test|find|find-transport|draft|adapt|medium|fill)$ ]]; then
     OPTIND=1
 else
     # Parse the options given without only avoiding "gapseq".
-    subcommand=$1
+    subcommand=false
     OPTIND=1
 fi
 

--- a/gapseq
+++ b/gapseq
@@ -165,16 +165,6 @@ elif [ "$subcommand" == "doall" ]; then
     [[ ! -s "$3" ]] && Rscript $dir/src/predict_medium.R -m "./${id}-draft.RDS" -p "$id-all-Pathways.tbl"
     Rscript $dir/src/gf.suite.R -m "./${id}-draft.RDS" -n "$medium" -c "./${id}-rxnWeights.RDS" -b 100 -g "./${id}-rxnXgenes.RDS"
 
-
-elif [ "$subcommand" == "adapt" ]; then
-    if [ "$2" == "add" ]; then
-        Rscript $dir/src/adapt.R -a $3 -m $4
-    elif [ "$2" == "remove" ]; then
-        Rscript $dir/src/adapt.R -r $3 -m $4
-    else
-        usage
-    fi
-
 else
     usage
 fi

--- a/gapseq
+++ b/gapseq
@@ -8,6 +8,7 @@ dir=$(dirname "$path")
 
 medium=$dir/dat/media/ALLmed.csv
 verbose=0
+n_threads=1
 
 usage()
 {
@@ -52,7 +53,9 @@ usage()
     echo "  -v              Show version."
     echo "  -h              Show this screen."
     echo "  -n              Enable noisy verbose mode."
-    exit 1
+    echo "  -K Number of threads for sequence alignments. If option is not provided, number of available CPUs will be automatically determined."
+
+exit 1
 }
 
 for arg in $@
@@ -65,8 +68,18 @@ do
     fi
 done
 
-OPTIND=1
-while getopts ":h?vm:n" opt; do
+# Check if there is a subcommand.
+if [[ "$1" =~ ^(test|find|find-transport|draft|adapt|medium|fill|doall)$ ]]; then
+    # If yes set OPTFIND 2 to detect the option.
+    subcommand=$1
+    OPTIND=2
+else
+    # If not stay at 1.
+    subcommand=false
+    OPTIND=1
+fi
+
+while getopts "hvnK:" opt; do
     case "$opt" in
         h|\?)
             usage
@@ -80,40 +93,51 @@ while getopts ":h?vm:n" opt; do
             ;;
         n)
             verbose=1
+            ;;
+        K)
+            n_threads=$OPTARG
+            ;;
         esac
 done
-shift $((OPTIND-1))
-[ "$1" = "--" ] && shift
+
+# Shift according to the options.
+if [[ "$subcommand" =~ ^(test|find|find-transport|draft|adapt|medium|fill|doall)$ ]]; then
+    shift $((OPTIND-2))
+else
+    shift $((OPTIND-1))
+fi
+
+[ "$subcommand" = "--" ] && shift
 [ "$#" -eq 0 ]  && usage
 
-if   [ "$1" == "test" ]; then
+if   [ "$subcommand" == "test" ]; then
     $dir/src/test.sh
 
-elif   [ "$1" == "find" ]; then
+elif   [ "$subcommand" == "find" ]; then
     shift
     $dir/src/gapseq_find.sh "$@"
 
-elif [ "$1" == "find-transport" ]; then
+elif [ "$subcommand" == "find-transport" ]; then
     shift
     $dir/src/transporter.sh "$@"
     
-elif [ "$1" == "draft" ]; then
+elif [ "$subcommand" == "draft" ]; then
     shift
     Rscript $dir/src/generate_GSdraft.R "$@"
 
-elif [ "$1" == "adapt" ]; then
+elif [ "$subcommand" == "adapt" ]; then
     shift
     Rscript $dir/src/adapt.R "$@"
     
-elif [ "$1" == "medium" ]; then
+elif [ "$subcommand" == "medium" ]; then
     shift
     Rscript $dir/src/predict_medium.R "$@"
 
-elif [ "$1" == "fill" ]; then
+elif [ "$subcommand" == "fill" ]; then
     shift
     Rscript $dir/src/gf.suite.R "$@"
 
-elif [ "$1" == "doall" ]; then
+elif [ "$subcommand" == "doall" ]; then
     parm=$(echo $@ | sed 's/doall//')
     file=$(readlink -f $2)
     base=$(basename "$file")
@@ -125,13 +149,14 @@ elif [ "$1" == "doall" ]; then
     taxonomy=auto
     [[ ("$3" == "Bacteria" || "$4" == "Bacteria") ]] && taxonomy=Bacteria
     [[ ("$3" == "Archaea" || "$4" == "Archaea") ]] && taxonomy=Archaea
-    $dir/src/gapseq_find.sh -v $verbose -b 200 -p all -t $taxonomy "$file"
+    $dir/src/gapseq_find.sh -v $verbose -b 200 -p all -t $taxonomy -K $n_threads "$file"
     $dir/src/transporter.sh -b 200 "$file"
     Rscript $dir/src/generate_GSdraft.R -r "$id-all-Reactions.tbl" -t "$id-Transporter.tbl" -c "$file" -u 200 -l 100 -p "$id-all-Pathways.tbl" -b $taxonomy
     [[ ! -s "$3" ]] && Rscript $dir/src/predict_medium.R -m "./${id}-draft.RDS" -p "$id-all-Pathways.tbl"
     Rscript $dir/src/gf.suite.R -m "./${id}-draft.RDS" -n "$medium" -c "./${id}-rxnWeights.RDS" -b 100 -g "./${id}-rxnXgenes.RDS"
 
-elif [ "$1" == "adapt" ]; then
+
+elif [ "$subcommand" == "adapt" ]; then
     if [ "$2" == "add" ]; then
         Rscript $dir/src/adapt.R -a $3 -m $4
     elif [ "$2" == "remove" ]; then

--- a/gapseq
+++ b/gapseq
@@ -68,43 +68,53 @@ do
     fi
 done
 
-# Check if there is a subcommand.
-if [[ "$1" =~ ^(test|find|find-transport|draft|adapt|medium|fill|doall)$ ]]; then
-    # If yes set OPTFIND 2 to detect the option.
+# Set a parsing variable to use getops when either the (1) doall subcommand is given or (2) only gapseq command is given.
+parse_options=true
+
+if [[ "$1" == "doall" ]]; then
+    # If yes set OPTIND 2 to avoid reading "gapseq doall" and to parse all the optins in the following while.
     subcommand=$1
     OPTIND=2
+elif [[ "$1" =~ ^(test|find|find-transport|draft|adapt|medium|fill)$ ]]; then
+    # If another command line (like find), the options are not parsed with getopts (as they will be parsed in their own script).
+    subcommand=$1
+    parse_options=false
+    OPTIND=1
 else
-    # If not stay at 1.
-    subcommand=false
+    # Parse the options given without only avoiding "gapseq".
+    subcommand=$1
     OPTIND=1
 fi
 
-while getopts "hvnK:" opt; do
-    case "$opt" in
-        h|\?)
-            usage
-            exit 0
-            ;;
-        v)
-            cd $dir
-            git_rev=$(git rev-parse --short HEAD 2>/dev/null)
-            echo gapseq version: $version $git_rev 
-            exit 0
-            ;;
-        n)
-            verbose=1
-            ;;
-        K)
-            n_threads=$OPTARG
-            ;;
-        esac
-done
+if [[ "$parse_options" == true ]]; then
+    while getopts "hvnK:" opt; do
+        case "$opt" in
+            h|\?)
+                usage
+                exit 0
+                ;;
+            v)
+                cd $dir
+                git_rev=$(git rev-parse --short HEAD 2>/dev/null)
+                echo gapseq version: $version $git_rev
+                exit 0
+                ;;
+            n)
+                verbose=1
+                ;;
+            K)
+                n_threads=$OPTARG
+                ;;
+            esac
+    done
+fi
 
-# Shift according to the options.
-if [[ "$subcommand" =~ ^(test|find|find-transport|draft|adapt|medium|fill|doall)$ ]]; then
-    shift $((OPTIND-2))
+if [[ "$subcommand" == "doall" ]]; then
+    # Remove the options parsed with getopts and keep "gapseq doall" and genome/medium filenames.
+    shift "$((OPTIND-2))"
 else
-    shift $((OPTIND-1))
+    # Do not remove anything.
+    shift "$((OPTIND-1))"
 fi
 
 [ "$subcommand" = "--" ] && shift
@@ -150,7 +160,7 @@ elif [ "$subcommand" == "doall" ]; then
     [[ ("$3" == "Bacteria" || "$4" == "Bacteria") ]] && taxonomy=Bacteria
     [[ ("$3" == "Archaea" || "$4" == "Archaea") ]] && taxonomy=Archaea
     $dir/src/gapseq_find.sh -v $verbose -b 200 -p all -t $taxonomy -K $n_threads "$file"
-    $dir/src/transporter.sh -b 200 "$file"
+    $dir/src/transporter.sh -b 200 -K $n_threads "$file"
     Rscript $dir/src/generate_GSdraft.R -r "$id-all-Reactions.tbl" -t "$id-Transporter.tbl" -c "$file" -u 200 -l 100 -p "$id-all-Pathways.tbl" -b $taxonomy
     [[ ! -s "$3" ]] && Rscript $dir/src/predict_medium.R -m "./${id}-draft.RDS" -p "$id-all-Pathways.tbl"
     Rscript $dir/src/gf.suite.R -m "./${id}-draft.RDS" -n "$medium" -c "./${id}-rxnWeights.RDS" -b 100 -g "./${id}-rxnXgenes.RDS"


### PR DESCRIPTION
Hi,

So according to the discussion in the issue #192, I have modified gapseq script to (I hope) better handle the parameters given to the subcommand `doall`.

The script only parse the parameters (with `getopts`) when the user gives `gapseq` or `gapseq doall`, for the other subcommand the parameters are parsed by the associated scripts.

I have also added the `-K` parameter to `gapseq doall`. I have several question for this implementation:

- I put the default n_thread to 1 but I have seen that in `gapseq_find.sh`, the default behavior is to use all the available CPUs. Would you preferred to also have this behavior in gapseq?
- I have also find the thread parameter (`setDTthreads`) in the R scripts [generate_GSdraft.R](https://github.com/jotech/gapseq/blob/master/src/generate_GSdraft.R#L20), [adapt.R](https://github.com/jotech/gapseq/blob/355da8ab9acc6649540c12250813802917637470/src/adapt.R#L56)and [gf.suite.R](https://github.com/jotech/gapseq/blob/master/src/gf.suite.R#L48). Could it be interesting to also gives the number of threads given by the user to these scripts?

I have also found that there was an unnecessary elif condition with `adapt`(line 134-142) as there was already another one (and simpler) elif condition for this subcommand.

I have not written in Bash for a long time so it may be not good. Also I did not find test to ensure that all works. I have run the different subcommands but as some of them are quite long, I think that my tests do not cover all case of use.
But if you find interesting thing in it, you can use it. 