### PR TITLE
Add gapseq to bioconda

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ git clone https://github.com/jotech/gapseq
 ```
 Detailed information on [installation and troubleshooting](https://github.com/jotech/gapseq/blob/master/docs/install.md).
 
+### Using Bioconda
+Gapseq has a [bioconda](https://anaconda.org/bioconda/gapseq) package. You must have conda/miniconda/[miniforge](https://github.com/conda-forge/miniforge#install) installed already.
+```bash
+conda create -c conda-forge -c bioconda -c r -n gapseq gapseq
+```
+
 
 ## Quickstart
 For detailed use cases and full tutorials, see the [documentation](https://gapseq.readthedocs.io/).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gapseq
 _Informed prediction and analysis of bacterial metabolic pathways and genome-scale networks_  
 [![Documentation Status](https://readthedocs.org/projects/gapseq/badge/?version=latest)](https://gapseq.readthedocs.io/en/latest/?badge=latest)
-[![DOI:10.1186/s13059-021-02295-1](https://zenodo.org/badge/DOI/10.1186/s13059-021-02295-1.svg)](https://doi.org/10.1186/s13059-021-02295-1)  
+[![DOI:10.1186/s13059-021-02295-1](https://zenodo.org/badge/DOI/10.1186/s13059-021-02295-1.svg)](https://doi.org/10.1186/s13059-021-02295-1) [![conda build](https://img.shields.io/conda/v/bioconda/gapseq)]([#installation](https://bioconda.github.io/recipes/gapseq/README.html))
 
 
 _gapseq_ is designed to combine metabolic pathway analysis with metabolic network reconstruction and curation.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gapseq
 _Informed prediction and analysis of bacterial metabolic pathways and genome-scale networks_  
 [![Documentation Status](https://readthedocs.org/projects/gapseq/badge/?version=latest)](https://gapseq.readthedocs.io/en/latest/?badge=latest)
-[![DOI:10.1186/s13059-021-02295-1](https://zenodo.org/badge/DOI/10.1186/s13059-021-02295-1.svg)](https://doi.org/10.1186/s13059-021-02295-1) [![conda build](https://img.shields.io/conda/v/bioconda/gapseq)](https://bioconda.github.io/recipes/gapseq/README.html)
+[![DOI:10.1186/s13059-021-02295-1](https://zenodo.org/badge/DOI/10.1186/s13059-021-02295-1.svg)](https://doi.org/10.1186/s13059-021-02295-1) [![conda build](https://img.shields.io/conda/v/bioconda/gapseq)](https://anaconda.org/bioconda/gapseq)
 
 
 _gapseq_ is designed to combine metabolic pathway analysis with metabolic network reconstruction and curation.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Gapseq has a [bioconda](https://anaconda.org/bioconda/gapseq) package. You must 
 conda create -c conda-forge -c bioconda -c r -n gapseq gapseq
 ```
 
+Hint: _When installing with bioconda, the gapseq binary will reside in your PATH, so you will not have to prepend "./" in front of gapseq. (Use "gapseq" instead of "./gapseq")._
+
 
 ## Quickstart
 For detailed use cases and full tutorials, see the [documentation](https://gapseq.readthedocs.io/).

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Detailed information on [installation and troubleshooting](https://github.com/jo
 ### Using Bioconda
 Gapseq has a [bioconda](https://anaconda.org/bioconda/gapseq) package. You must have conda/miniconda/[miniforge](https://github.com/conda-forge/miniforge#install) installed already.
 ```bash
-conda create -c conda-forge -c bioconda -c r -n gapseq gapseq
+conda create -c conda-forge -c bioconda -n gapseq gapseq
 ```
 
 Hint: _When installing with bioconda, the gapseq binary will reside in your PATH, so you will not have to prepend "./" in front of gapseq. (Use "gapseq" instead of "./gapseq")._

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # gapseq
 _Informed prediction and analysis of bacterial metabolic pathways and genome-scale networks_  
 [![Documentation Status](https://readthedocs.org/projects/gapseq/badge/?version=latest)](https://gapseq.readthedocs.io/en/latest/?badge=latest)
-[![DOI:10.1186/s13059-021-02295-1](https://zenodo.org/badge/DOI/10.1186/s13059-021-02295-1.svg)](https://doi.org/10.1186/s13059-021-02295-1) [![conda build](https://img.shields.io/conda/v/bioconda/gapseq)]([#installation](https://bioconda.github.io/recipes/gapseq/README.html))
+[![DOI:10.1186/s13059-021-02295-1](https://zenodo.org/badge/DOI/10.1186/s13059-021-02295-1.svg)](https://doi.org/10.1186/s13059-021-02295-1) [![conda build](https://img.shields.io/conda/v/bioconda/gapseq)](https://bioconda.github.io/recipes/gapseq/README.html)
 
 
 _gapseq_ is designed to combine metabolic pathway analysis with metabolic network reconstruction and curation.


### PR DESCRIPTION
Dear Gapseq developers

I made a Bioconda recipe for Gapseq. 
https://anaconda.org/bioconda/gapseq

I have a large interest in applying Gapseq to my research. And especially for designing larger pipelines as well as for teaching purposes it is very handy to have an easily installable option of this great tool.

I had some issues installing the Sybilsbml package for R. I'm not entirely sure if it is strictly necessary for basic use cases. And I guess a reasonable workaround for now could be that a user manually installs this package (as outlined in the current conda installation instructions already). The essence is that it is possible to add this package through the bioconda recipe, but I think it would be much better if the original Cran package was fixed instead, as it makes everything much easier for everyone. We can also think about making a script available in the Bioconda package that automatically installs the Sybilsbml Cran-archived package.

As all dependencies have to sit inside conda-forge or bioconda itself, I had to take another detour and make a recipe for r-chnosz as well (https://github.com/conda-forge/r-chnosz-feedstock).

Publishing packages from Github on bioconda uses the "autobump" feature which means that everytime you publish a new release on your Github page, the new version is automatically pushed to Bioconda. I incorporated the `gapseq test` in the recipe which ensures that only the latest _working_ version is available on Bioconda. You can check out how I made the recipe in more detail here https://github.com/bioconda/bioconda-recipes/pull/47417/files

Anyway - please give the package a spin. I added a basic installation instruction in the README.md so you can try it out - Let me know what you think.

This pull request is in response to issue https://github.com/jotech/gapseq/issues/60

Best, Carl 