### PR TITLE
Enforce minimum required growth rate in gapfill step 1

### DIFF
--- a/src/gapfill4.R
+++ b/src/gapfill4.R
@@ -1,4 +1,4 @@
-gapfill4 <- function(mod.orig, mod.full, rxn.weights, min.gr = 0.1, bcore = 50,
+gapfill4 <- function(mod.orig, mod.full, rxn.weights, min.gr = 0.01, bcore = 50,
                      dummy.weight = 100, script.dir, core.only = FALSE, verbose=verbose, gs.origin = NA, rXg.tab, env = "") {
 
   source(paste0(script.dir, "/sysBiolAlg_mtfClass2.R"))
@@ -88,6 +88,7 @@ gapfill4 <- function(mod.orig, mod.full, rxn.weights, min.gr = 0.1, bcore = 50,
     max.iter  <- 100
     n.iter    <- 1
     pFBAcoeff <- 1e-3
+    mod@lowbnd[which(mod@obj_coef == 1)] <- min.gr # enforce minimum required growth rate
     while(sol.tmp <= 0 & n.iter <= max.iter) {
       modj_warm <- sysBiolAlg(mod,
                               algorithm = "mtf2",

--- a/src/gf.suite.R
+++ b/src/gf.suite.R
@@ -19,7 +19,7 @@ spec <- matrix(c(
   'relaxed.constraints', 'r', 2, "logical", "Save final model as unconstraint network (i.e. all exchange reactions are open). Default: FALSE",
   'environment', 'e', 2, "character", "Adjusting reaction directions according to specific environmental conditions. See documentation for details. CAUTION: experimental option!",
   'write.cs.ferm', 'w', 2, "logical", "Write a list with found carbon sources and fermentation products",
-  'min.obj.val', 'k', 2, "numeric", "Minimum growth rate that should be achieved by gap-filling. Default: 0.05"
+  'min.obj.val', 'k', 2, "numeric", "Minimum growth rate that should be achieved by gap-filling. Default: 0.01"
 ), ncol = 5, byrow = T)
 
 opt <- getopt(spec)
@@ -71,7 +71,7 @@ if ( is.null(opt$no.core) ) { opt$no.core = F }
 if ( is.null(opt$relaxed.constraints) ) { opt$relaxed.constraints = F }
 if ( is.null(opt$environment) ) { opt$environment = "" }
 if ( is.null(opt$write.cs.ferm) ) { opt$write.cs.ferm = F }
-if ( is.null(opt$min.obj.val) ) { opt$min.obj.val = 0.05 }
+if ( is.null(opt$min.obj.val) ) { opt$min.obj.val = 0.01 }
 
 # deprecation notice for flag '-o'
 if(!is.null(opt$depr.output.dir)) {


### PR DESCRIPTION
- Option for minimum required growth rate was already part of the "gapseq fill" module.
- However, growth rate was not always achieved, since it was not added as constraint in gapfill step 1.
- refers to #232