### PR TITLE
Update gapseq_env.yml

### DIFF
--- a/gapseq_env.yml
+++ b/gapseq_env.yml
@@ -27,7 +27,7 @@ dependencies:
   - r-stringi
   - r-getopt
   - r-r.utils
-  - r-cobrar >=0.1.1
+  - r-cobrar >=0.1.2
   - r-biocmanager
   - bioconductor-biostrings
   - r-jsonlite


### PR DESCRIPTION
Require r-cobrar>=0.1.2

refers to #259 

cobrar v0.1.1 had problem exporting SBML models, if gene names contained special characters, even dashes, as these characters are not allowed in gene IDs in SBML.